### PR TITLE
Init tests for httprox

### DIFF
--- a/src/main/java/org/commonjava/indy/service/httprox/HttpProxy.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/HttpProxy.java
@@ -18,7 +18,7 @@ package org.commonjava.indy.service.httprox;
 
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
-import org.commonjava.indy.service.httprox.config.IndyGenericProxyConfiguration;
+import org.commonjava.indy.service.httprox.config.ProxyConfiguration;
 import org.commonjava.indy.service.httprox.handler.ProxyAcceptHandler;
 import org.commonjava.propulsor.boot.PortFinder;
 import org.slf4j.Logger;
@@ -41,7 +41,7 @@ public class HttpProxy {
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     @Inject
-    private IndyGenericProxyConfiguration config;
+    private ProxyConfiguration config;
 
     @Inject
     private ProxyAcceptHandler acceptHandler;
@@ -52,7 +52,7 @@ public class HttpProxy {
     protected HttpProxy() {
     }
 
-    public HttpProxy(final IndyGenericProxyConfiguration config, ProxyAcceptHandler acceptHandler) {
+    public HttpProxy(final ProxyConfiguration config, ProxyAcceptHandler acceptHandler) {
         this.config = config;
         this.acceptHandler = acceptHandler;
     }

--- a/src/main/java/org/commonjava/indy/service/httprox/HttpProxy.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/HttpProxy.java
@@ -57,7 +57,6 @@ public class HttpProxy {
         this.acceptHandler = acceptHandler;
     }
 
-
     public void onStart(@Observes StartupEvent ev) {
         String bind = "0.0.0.0";
 

--- a/src/main/java/org/commonjava/indy/service/httprox/client/content/ContentRetrievalService.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/client/content/ContentRetrievalService.java
@@ -1,4 +1,4 @@
-package org.commonjava.indy.service.httprox.client.repository;
+package org.commonjava.indy.service.httprox.client.content;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 

--- a/src/main/java/org/commonjava/indy/service/httprox/client/repository/Transfer.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/client/repository/Transfer.java
@@ -1,8 +1,0 @@
-package org.commonjava.indy.service.httprox.client.repository;
-
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
-@JsonIgnoreProperties(ignoreUnknown = true)
-public class Transfer
-{
-}

--- a/src/main/java/org/commonjava/indy/service/httprox/config/ProxyConfiguration.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/config/ProxyConfiguration.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 
 @Startup
 @ApplicationScoped
-public class IndyGenericProxyConfiguration {
+public class ProxyConfiguration {
     @Inject
     @ConfigProperty(name = "proxy.port")
     Optional<Integer> port;

--- a/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyAcceptHandler.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyAcceptHandler.java
@@ -15,8 +15,8 @@
  */
 package org.commonjava.indy.service.httprox.handler;
 
-import org.commonjava.indy.service.httprox.client.repository.ContentRetrievalService;
-import org.commonjava.indy.service.httprox.config.IndyGenericProxyConfiguration;
+import org.commonjava.indy.service.httprox.client.content.ContentRetrievalService;
+import org.commonjava.indy.service.httprox.config.ProxyConfiguration;
 import org.commonjava.indy.service.httprox.util.RepoCreator;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.slf4j.Logger;
@@ -37,7 +37,7 @@ public class ProxyAcceptHandler implements ChannelListener<AcceptingChannel<Stre
     public static final String HTTPROX_ORIGIN = "httprox";
 
     @Inject
-    IndyGenericProxyConfiguration config;
+    ProxyConfiguration config;
 
     @Inject
     @RestClient

--- a/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyAcceptHandler.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyAcceptHandler.java
@@ -15,8 +15,10 @@
  */
 package org.commonjava.indy.service.httprox.handler;
 
+import org.commonjava.indy.service.httprox.client.repository.ContentRetrievalService;
 import org.commonjava.indy.service.httprox.config.IndyGenericProxyConfiguration;
 import org.commonjava.indy.service.httprox.util.RepoCreator;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xnio.ChannelListener;
@@ -36,6 +38,10 @@ public class ProxyAcceptHandler implements ChannelListener<AcceptingChannel<Stre
 
     @Inject
     IndyGenericProxyConfiguration config;
+
+    @Inject
+    @RestClient
+    ContentRetrievalService contentRetrievalService;
 
     public ProxyAcceptHandler() {
 
@@ -66,7 +72,7 @@ public class ProxyAcceptHandler implements ChannelListener<AcceptingChannel<Stre
         ProxyRepositoryCreator repoCreator = new RepoCreator();
 
         final ProxyResponseWriter writer =
-                new ProxyResponseWriter( config, repoCreator, accepted );
+                new ProxyResponseWriter( config, repoCreator, accepted, contentRetrievalService );
 
         logger.debug("Setting writer: {}", writer);
         sink.getWriteSetter().set(writer);

--- a/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyResponseWriter.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyResponseWriter.java
@@ -18,8 +18,8 @@ package org.commonjava.indy.service.httprox.handler;
 import org.apache.http.HttpRequest;
 import org.apache.http.RequestLine;
 import org.commonjava.indy.model.core.ArtifactStore;
-import org.commonjava.indy.service.httprox.client.repository.ContentRetrievalService;
-import org.commonjava.indy.service.httprox.config.IndyGenericProxyConfiguration;
+import org.commonjava.indy.service.httprox.client.content.ContentRetrievalService;
+import org.commonjava.indy.service.httprox.config.ProxyConfiguration;
 import org.commonjava.indy.service.httprox.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,7 +43,7 @@ public final class ProxyResponseWriter
 
     private Throwable error;
     private HttpRequest httpRequest;
-    private IndyGenericProxyConfiguration config;
+    private ProxyConfiguration config;
     private ProxyRepositoryCreator repoCreator;
 
     private ConduitStreamSourceChannel sourceChannel;
@@ -51,7 +51,7 @@ public final class ProxyResponseWriter
 
     private ContentRetrievalService contentRetrievalService;
 
-    public ProxyResponseWriter(final IndyGenericProxyConfiguration config, final ProxyRepositoryCreator repoCreator,
+    public ProxyResponseWriter(final ProxyConfiguration config, final ProxyRepositoryCreator repoCreator,
                                final StreamConnection accepted, final ContentRetrievalService contentRetrievalService )
     {
         this.config = config;

--- a/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyResponseWriter.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyResponseWriter.java
@@ -18,6 +18,7 @@ package org.commonjava.indy.service.httprox.handler;
 import org.apache.http.HttpRequest;
 import org.apache.http.RequestLine;
 import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.service.httprox.client.repository.ContentRetrievalService;
 import org.commonjava.indy.service.httprox.config.IndyGenericProxyConfiguration;
 import org.commonjava.indy.service.httprox.util.*;
 import org.slf4j.Logger;
@@ -48,13 +49,16 @@ public final class ProxyResponseWriter
     private ConduitStreamSourceChannel sourceChannel;
     private SocketAddress peerAddress;
 
+    private ContentRetrievalService contentRetrievalService;
+
     public ProxyResponseWriter(final IndyGenericProxyConfiguration config, final ProxyRepositoryCreator repoCreator,
-                               final StreamConnection accepted )
+                               final StreamConnection accepted, final ContentRetrievalService contentRetrievalService )
     {
         this.config = config;
         this.repoCreator = repoCreator;
         this.peerAddress = accepted.getPeerAddress();
         this.sourceChannel = accepted.getSourceChannel();
+        this.contentRetrievalService = contentRetrievalService;
     }
 
     @Override
@@ -92,7 +96,7 @@ public final class ProxyResponseWriter
         if (error == null) {
 
             ProxyResponseHelper proxyResponseHelper =
-                    new ProxyResponseHelper( httpRequest, config, repoCreator );
+                    new ProxyResponseHelper( httpRequest, config, repoCreator, contentRetrievalService );
 
             try
             {

--- a/src/main/java/org/commonjava/indy/service/httprox/handler/TransferStreamingOutput.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/handler/TransferStreamingOutput.java
@@ -1,0 +1,46 @@
+package org.commonjava.indy.service.httprox.handler;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.output.CountingOutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.StreamingOutput;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class TransferStreamingOutput
+        implements StreamingOutput
+{
+
+    private static final String TRANSFER_METRIC_NAME = "indy.transferred.content";
+
+    private InputStream stream;
+
+
+    public TransferStreamingOutput( final InputStream stream )
+    {
+        this.stream = stream;
+    }
+
+    @Override
+    public void write( final OutputStream out )
+            throws IOException, WebApplicationException
+    {
+        try
+        {
+            CountingOutputStream cout = new CountingOutputStream( out );
+            IOUtils.copy( stream, cout );
+
+            Logger logger = LoggerFactory.getLogger( getClass() );
+            logger.trace( "Wrote: {} bytes", cout.getByteCount() );
+        }
+        finally
+        {
+            IOUtils.closeQuietly( stream );
+        }
+    }
+
+}

--- a/src/main/java/org/commonjava/indy/service/httprox/util/ProxyResponseHelper.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/util/ProxyResponseHelper.java
@@ -15,15 +15,14 @@
  */
 package org.commonjava.indy.service.httprox.util;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpStatus;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.model.core.RemoteRepository;
-import org.commonjava.indy.service.httprox.client.repository.*;
-import org.commonjava.indy.service.httprox.config.IndyGenericProxyConfiguration;
+import org.commonjava.indy.service.httprox.client.content.ContentRetrievalService;
+import org.commonjava.indy.service.httprox.config.ProxyConfiguration;
 import org.commonjava.indy.service.httprox.handler.ProxyCreationResult;
 import org.commonjava.indy.service.httprox.handler.ProxyRepositoryCreator;
 import org.commonjava.indy.service.httprox.handler.TransferStreamingOutput;
@@ -34,8 +33,6 @@ import javax.ws.rs.core.Response;
 import java.io.*;
 import java.net.URL;
 
-import static org.commonjava.indy.model.core.GenericPackageTypeDescriptor.GENERIC_PKG_KEY;
-
 public class ProxyResponseHelper
 {
     private final Logger logger = LoggerFactory.getLogger( getClass() );
@@ -44,7 +41,7 @@ public class ProxyResponseHelper
 
     private final HttpRequest httpRequest;
 
-    private final IndyGenericProxyConfiguration config;
+    private final ProxyConfiguration config;
 
     private boolean transferred;
 
@@ -52,7 +49,7 @@ public class ProxyResponseHelper
 
     private ContentRetrievalService contentRetrievalService;
 
-    public ProxyResponseHelper(HttpRequest httpRequest, IndyGenericProxyConfiguration config, ProxyRepositoryCreator repoCreator, ContentRetrievalService contentRetrievalService )
+    public ProxyResponseHelper(HttpRequest httpRequest, ProxyConfiguration config, ProxyRepositoryCreator repoCreator, ContentRetrievalService contentRetrievalService )
     {
         this.httpRequest = httpRequest;
         this.config = config;
@@ -231,7 +228,7 @@ public class ProxyResponseHelper
                 responseStream.write(out);
             }
 
-            http.writeExistingTransfer(in, true, "");
+            http.writeExistingTransfer(in, true, response.getHeaders());
         }
         else if ( response.getStatus() == HttpStatus.SC_NOT_FOUND )
         {

--- a/src/test/java/org/commonjava/service/httprox/HttpProxyTest.java
+++ b/src/test/java/org/commonjava/service/httprox/HttpProxyTest.java
@@ -1,0 +1,130 @@
+package org.commonjava.service.httprox;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpStatus;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.conn.routing.HttpRoutePlanner;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.DefaultProxyRoutePlanner;
+import org.commonjava.indy.service.httprox.client.repository.RepositoryService;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@QuarkusTest
+public class HttpProxyTest
+{
+
+    private static final String USER = "user";
+
+    private static final String PASS = "password";
+
+    private static final String HOST = "127.0.0.1";
+
+    private static int proxyPort = 8085;
+
+    @Inject
+    @RestClient
+    RepositoryService repositoryService;
+
+    @Test
+    public void proxySimplePomAndAutoCreateRemoteRepo()
+            throws Exception
+    {
+        final String testRepo = "test";
+
+        final String url = "http://remote.example:80/test/org/test/simple/1/simple.pom";
+        final String testPomContents = loadResource("simple.pom");
+
+        final HttpGet get = new HttpGet( url );
+        final CloseableHttpClient client = proxiedHttp();
+        CloseableHttpResponse response = null;
+
+        InputStream stream = null;
+        try
+        {
+            response = client.execute( get, proxyContext( USER, PASS ) );
+            stream = response.getEntity().getContent();
+            final String resultingPom = IOUtils.toString( stream );
+
+            assertThat( resultingPom, notNullValue() );
+            assertThat( resultingPom, equalTo( testPomContents ) );
+        }
+        finally
+        {
+            IOUtils.closeQuietly( stream );
+        }
+
+        //TODO check if remote repo created
+        //repositoryService.repoExists("GENERIC_PKG_KEY", StoreType.remote.name(), "httprox_remote-example_80");
+
+    }
+
+    @Test
+    public void proxy404()
+            throws Exception
+    {
+        final String testRepo = "test";
+
+        final String url = "http://remote.example:80/test/org/test/simple/1/simple-1.pom";
+
+        final HttpGet get = new HttpGet( url );
+        final CloseableHttpClient client = proxiedHttp();
+        CloseableHttpResponse response = null;
+
+        final InputStream stream = null;
+        try
+        {
+            response = client.execute( get, proxyContext( USER, PASS ) );
+            assertThat( response.getStatusLine().getStatusCode(), equalTo( HttpStatus.SC_NOT_FOUND ) );
+        }
+        finally
+        {
+            IOUtils.closeQuietly( stream );
+            //HttpUtil.cleanupResources( client, get, response );
+        }
+
+    }
+
+    protected HttpClientContext proxyContext(final String user, final String pass )
+    {
+        final CredentialsProvider creds = new BasicCredentialsProvider();
+        creds.setCredentials( new AuthScope( HOST, proxyPort ), new UsernamePasswordCredentials( user, pass ) );
+        final HttpClientContext ctx = HttpClientContext.create();
+        ctx.setCredentialsProvider( creds );
+
+        return ctx;
+    }
+
+    protected CloseableHttpClient proxiedHttp()
+            throws Exception
+    {
+        final HttpRoutePlanner planner = new DefaultProxyRoutePlanner( new HttpHost( HOST, proxyPort ) );
+        return HttpClients.custom().setRoutePlanner( planner ).build();
+    }
+
+    protected String loadResource(String resource) throws IOException
+    {
+        final InputStream stream = Thread.currentThread().getContextClassLoader().getResourceAsStream( resource );
+
+        return IOUtils.toString( stream );
+    }
+
+
+}

--- a/src/test/java/org/commonjava/service/httprox/client/ContentRetrievalServiceTest.java
+++ b/src/test/java/org/commonjava/service/httprox/client/ContentRetrievalServiceTest.java
@@ -1,7 +1,7 @@
 package org.commonjava.service.httprox.client;
 
 import io.quarkus.test.junit.QuarkusTest;
-import org.commonjava.indy.service.httprox.client.repository.ContentRetrievalService;
+import org.commonjava.indy.service.httprox.client.content.ContentRetrievalService;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/org/commonjava/service/httprox/client/mock/MockableContentRetrievalService.java
+++ b/src/test/java/org/commonjava/service/httprox/client/mock/MockableContentRetrievalService.java
@@ -1,0 +1,34 @@
+package org.commonjava.service.httprox.client.mock;
+
+import io.quarkus.test.Mock;
+import org.apache.commons.io.FilenameUtils;
+import org.commonjava.indy.service.httprox.client.repository.ContentRetrievalService;
+import org.commonjava.indy.service.httprox.handler.TransferStreamingOutput;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.io.InputStream;
+
+@Mock
+@RestClient
+public class MockableContentRetrievalService implements ContentRetrievalService
+{
+    @Override
+    public Response doGet( String type, String name, String path )
+    {
+
+        InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream( FilenameUtils.getName(path) );
+        if ( in != null )
+        {
+            final Response.ResponseBuilder builder = Response.ok(
+                    new TransferStreamingOutput(in));
+            return builder.build();
+        }
+        else
+        {
+            Response.ResponseBuilder builder = Response.status(Response.Status.NOT_FOUND ).type( MediaType.TEXT_PLAIN ).entity( "" );
+            return builder.build();
+        }
+    }
+}

--- a/src/test/java/org/commonjava/service/httprox/client/mock/MockableContentRetrievalService.java
+++ b/src/test/java/org/commonjava/service/httprox/client/mock/MockableContentRetrievalService.java
@@ -2,7 +2,7 @@ package org.commonjava.service.httprox.client.mock;
 
 import io.quarkus.test.Mock;
 import org.apache.commons.io.FilenameUtils;
-import org.commonjava.indy.service.httprox.client.repository.ContentRetrievalService;
+import org.commonjava.indy.service.httprox.client.content.ContentRetrievalService;
 import org.commonjava.indy.service.httprox.handler.TransferStreamingOutput;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 

--- a/src/test/java/org/commonjava/service/httprox/client/mock/MockableRepositoryService.java
+++ b/src/test/java/org/commonjava/service/httprox/client/mock/MockableRepositoryService.java
@@ -1,0 +1,22 @@
+package org.commonjava.service.httprox.client.mock;
+
+import io.quarkus.test.Mock;
+import org.commonjava.indy.service.httprox.client.repository.RepositoryService;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import javax.ws.rs.core.Response;
+
+@Mock
+@RestClient
+public class MockableRepositoryService implements RepositoryService
+{
+    @Override
+    public Response repoExists(String packageType, String type, String name) {
+        return null;
+    }
+
+    @Override
+    public Response createStore(String packageType, String type, String store) {
+        return null;
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+proxy.port=8085

--- a/src/test/resources/simple.pom
+++ b/src/test/resources/simple.pom
@@ -1,0 +1,23 @@
+<!--
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.test</groupId>
+    <artifactId>simple</artifactId>
+    <version>1</version>
+</project>


### PR DESCRIPTION
For retrieving the artifacts, generic proxy service needs to access indy REST first and then stream the result back, the pr I try to use the `PipedOutputStream` in `ProxyResponseHelper` to transit it from Indy response to client. Not sure if this is right, please help to review. And there are two tests in `HttpProxyTest` for it. 