### PR TITLE
Cache store to avoid the loads to main indy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>2.3.0.Final</quarkus.platform.version>
         <quarkus.package.type>uber-jar</quarkus.package.type>
+        <infinispanVersion>12.1.11.Final</infinispanVersion>
     </properties>
 
     <dependencyManagement>
@@ -180,6 +181,12 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-oidc-client-filter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-core</artifactId>
+            <version>${infinispanVersion}</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyAcceptHandler.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyAcceptHandler.java
@@ -21,6 +21,7 @@ import org.commonjava.indy.service.httprox.client.content.ContentRetrievalServic
 import org.commonjava.indy.service.httprox.client.repository.RepositoryService;
 import org.commonjava.indy.service.httprox.config.ProxyConfiguration;
 import org.commonjava.indy.service.httprox.keycloak.KeycloakProxyAuthenticator;
+import org.commonjava.indy.service.httprox.util.CacheProducer;
 import org.commonjava.indy.service.httprox.util.OtelAdapter;
 import org.commonjava.indy.service.httprox.util.RepoCreator;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
@@ -62,6 +63,9 @@ public class ProxyAcceptHandler implements ChannelListener<AcceptingChannel<Stre
 
     @Inject
     OtelAdapter otel;
+
+    @Inject
+    CacheProducer cacheProducer;
 
     @Inject
     Tokens tokens;
@@ -106,7 +110,7 @@ public class ProxyAcceptHandler implements ChannelListener<AcceptingChannel<Stre
         ProxyRepositoryCreator repoCreator = new RepoCreator();
 
         final ProxyResponseWriter writer =
-                new ProxyResponseWriter( config, repoCreator, accepted, repositoryService, contentRetrievalService, proxyExecutor.getExecutor(), proxyAuthenticator, new IndyObjectMapper(false), tokens, start, otel );
+                new ProxyResponseWriter( config, repoCreator, accepted, repositoryService, contentRetrievalService, proxyExecutor.getExecutor(), proxyAuthenticator, new IndyObjectMapper(false), tokens, cacheProducer, start, otel );
 
         logger.debug("Setting writer: {}", writer);
         sink.getWriteSetter().set(writer);

--- a/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyResponseWriter.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyResponseWriter.java
@@ -75,6 +75,9 @@ public final class ProxyResponseWriter
     private KeycloakProxyAuthenticator proxyAuthenticator;
 
     private IndyObjectMapper indyObjectMapper;
+
+    private CacheProducer cacheProducer;
+
     private OtelAdapter otel;
 
     private long startNanos;
@@ -83,7 +86,7 @@ public final class ProxyResponseWriter
                                final StreamConnection accepted, final RepositoryService repositoryService,
                                final ContentRetrievalService contentRetrievalService, final WeftExecutorService executor,
                                final KeycloakProxyAuthenticator proxyAuthenticator, final IndyObjectMapper indyObjectMapper,
-                               final Tokens tokens, final long start, final OtelAdapter otel)
+                               final Tokens tokens, final CacheProducer cacheProducer, final long start, final OtelAdapter otel)
     {
         this.config = config;
         this.repoCreator = repoCreator;
@@ -95,6 +98,7 @@ public final class ProxyResponseWriter
         this.proxyAuthenticator = proxyAuthenticator;
         this.indyObjectMapper = indyObjectMapper;
         startNanos = start;
+        this.cacheProducer = cacheProducer;
         this.otel = otel;
         this.tokens = tokens;
     }
@@ -158,7 +162,7 @@ public final class ProxyResponseWriter
         if (error == null) {
 
             ProxyResponseHelper proxyResponseHelper =
-                    new ProxyResponseHelper( httpRequest, config, repoCreator, repositoryService, contentRetrievalService, indyObjectMapper, otel );
+                    new ProxyResponseHelper( httpRequest, config, repoCreator, repositoryService, contentRetrievalService, indyObjectMapper, cacheProducer, otel );
 
             try
             {

--- a/src/main/java/org/commonjava/indy/service/httprox/util/CacheProducer.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/util/CacheProducer.java
@@ -1,0 +1,44 @@
+package org.commonjava.indy.service.httprox.util;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.manager.EmbeddedCacheManager;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@ApplicationScoped
+public class CacheProducer
+{
+
+    private EmbeddedCacheManager cacheManager;
+
+    private Map<String, Cache> caches = new ConcurrentHashMap<>();
+
+    @PostConstruct
+    public void start()
+    {
+        startEmbeddedManager();
+    }
+
+    private void startEmbeddedManager()
+    {
+        cacheManager = new DefaultCacheManager();
+    }
+
+    public synchronized <K, V> Cache<K, V> getCache( String named )
+    {
+        return caches.computeIfAbsent( named, ( k ) -> buildCache(named));
+    }
+
+    private Cache buildCache(String named)
+    {
+        cacheManager.defineConfiguration( named, new ConfigurationBuilder().build() );
+        return cacheManager.getCache(named, Boolean.TRUE);
+    }
+
+
+}


### PR DESCRIPTION
When I grabbed one builds from production, found the case that one build request hundreds of generic request, that means it will request to check the same store frequently, the PR added the in-momery cache for the store to avoid the loads to main indy. 