### PR TITLE
Support multi threads setting for NIO handler

### DIFF
--- a/src/main/java/org/commonjava/indy/service/httprox/HttpProxy.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/HttpProxy.java
@@ -23,10 +23,7 @@ import org.commonjava.indy.service.httprox.handler.ProxyAcceptHandler;
 import org.commonjava.propulsor.boot.PortFinder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xnio.OptionMap;
-import org.xnio.StreamConnection;
-import org.xnio.Xnio;
-import org.xnio.XnioWorker;
+import org.xnio.*;
 import org.xnio.channels.AcceptingChannel;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -65,7 +62,10 @@ public class HttpProxy {
         XnioWorker worker;
         try {
             worker = Xnio.getInstance()
-                    .createWorker(OptionMap.EMPTY);
+                    .createWorker(OptionMap.builder()
+                            .set(Options.WORKER_IO_THREADS, config.getIoThreads())
+                            .set(Options.WORKER_TASK_CORE_THREADS, config.getTaskThreads())
+                            .getMap());
 
             final InetSocketAddress addr;
             if (config.getPort() < 1) {

--- a/src/main/java/org/commonjava/indy/service/httprox/config/ProxyConfiguration.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/config/ProxyConfiguration.java
@@ -37,6 +37,10 @@ public class ProxyConfiguration
 
     private static final String DEFAULT_PROXY_REALM = "httprox";
 
+    private static final int DEFAULT_WORKER_IO_THREADS = 10;
+
+    private static final int DEFAULT_WORKER_TASK_THREADS = 10;
+
     @ConfigProperty(name = "proxy.port")
     Optional<Integer> port;
 
@@ -63,6 +67,12 @@ public class ProxyConfiguration
 
     @ConfigProperty( name="proxy.realm", defaultValue = DEFAULT_PROXY_REALM )
     public String proxyRealm;
+
+    @ConfigProperty(name="proxy.worker.io.threads")
+    public Integer ioThreads;
+
+    @ConfigProperty(name="proxy.worker.task.threads")
+    public Integer taskThreads;
 
     public Integer getPort() {
         return port.orElse(8081);
@@ -151,5 +161,21 @@ public class ProxyConfiguration
     public void setProxyRealm(String proxyRealm)
     {
         this.proxyRealm = proxyRealm;
+    }
+
+    public Integer getIoThreads() {
+        return ioThreads == null ? DEFAULT_WORKER_IO_THREADS : ioThreads;
+    }
+
+    public void setIoThreads(Integer ioThreads) {
+        this.ioThreads = ioThreads;
+    }
+
+    public Integer getTaskThreads() {
+        return taskThreads == null ? DEFAULT_WORKER_TASK_THREADS : taskThreads;
+    }
+
+    public void setTaskThreads(Integer taskThreads) {
+        this.taskThreads = taskThreads;
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -26,6 +26,11 @@ proxy:
   port: 8082
   realm: httprox
   secured: true
+  worker:
+    io:
+      threads: 10
+    task:
+      threads: 10
 
 service_proxy:
   read-timeout: 30m

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -2,6 +2,11 @@ proxy:
   port: 8085
   realm: httprox
   secured: true
+  worker:
+    io:
+      threads: 10
+    task:
+      threads: 10
 
 service_proxy:
   read-timeout: 30m


### PR DESCRIPTION
There is performance issue when lots of requests through the proxy, and checked the logs and found that looks there is only one thread to handle the request:
`(XNIO-1 I/O-1)`
let's try the multi threads setting and see how is the performance going. 