### PR TITLE
Sync the method for querying the repository

### DIFF
--- a/src/main/java/org/commonjava/indy/service/httprox/util/ProxyResponseHelper.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/util/ProxyResponseHelper.java
@@ -15,7 +15,6 @@
  */
 package org.commonjava.indy.service.httprox.util;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.opentelemetry.api.trace.Span;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.http.HttpMethod;
@@ -127,7 +126,7 @@ public class ProxyResponseHelper
         return store;
     }
 
-    private ArtifactStore doGetArtifactStore(String trackingId, final URL url )
+    private synchronized ArtifactStore doGetArtifactStore(String trackingId, final URL url )
                     throws IndyProxyException
     {
 


### PR DESCRIPTION
Checked from the logs, this should be synced in case the parallel requests for querying/creating the same repository. 