### PR TITLE
Close the connection when exception happens

### DIFF
--- a/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyMITMSSLServer.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyMITMSSLServer.java
@@ -212,11 +212,17 @@ public class ProxyMITMSSLServer implements Runnable
                             logger.debug( "MITM server failed to get request from client" );
                         }
                     }
-                }
-                catch ( SocketTimeoutException ste )
-                {
-                    logger.error( "Socket read timeout with client hostname: {}, on port: {}.", host, port );
-                    throw ste;
+                    catch ( SocketTimeoutException ste )
+                    {
+                        logger.error( "Socket read timeout with client hostname: {}, on port: {}.", host, port, ste );
+                        try (BufferedOutputStream out = new BufferedOutputStream( socket.getOutputStream() );
+                             HttpConduitWrapper http = new HttpConduitWrapper( new OutputStreamSinkChannel( out ), null ))
+                        {
+                            http.writeClose();
+                            http.close();
+                            out.flush();
+                        }
+                    }
                 }
             }
             logger.debug( "MITM server closed" );

--- a/src/main/java/org/commonjava/indy/service/httprox/util/HttpConduitWrapper.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/util/HttpConduitWrapper.java
@@ -83,7 +83,7 @@ public class HttpConduitWrapper
         sinkChannel.write(b);
     }
 
-    private void writeClose()
+    public void writeClose()
             throws IOException {
         writeHeader("Connection", "close\r\n");
     }


### PR DESCRIPTION
When the timeout happens, it should close the connection rather than handling the exception, throwing exception and handling it later cause it hangs on the client(builder tool), ref MMENG-3127. 