### PR TITLE
Revert "redirect to the default page if path is null"

### DIFF
--- a/src/main/java/org/commonjava/indy/service/httprox/client/content/ContentRetrievalService.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/client/content/ContentRetrievalService.java
@@ -33,10 +33,6 @@ public class ContentRetrievalService
 
     public Uni<okhttp3.Response> doGet( String trackingId, String type, String name, String path ) throws Exception
     {
-        if ( path.equals("/") )
-        {
-            path = path + "index.html";
-        }
         String path1;
         if ( trackingId != null )
         {


### PR DESCRIPTION
Let's rollback this redirection since it does not work for some cases. 
This reverts commit 70f36ca76f9a48c0050b9b6e78144620ae40648b.