### PR TITLE
Check the state of the channel before reading

### DIFF
--- a/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyRequestReader.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyRequestReader.java
@@ -72,6 +72,17 @@ public final class ProxyRequestReader
     public void handleEvent(final ConduitStreamSourceChannel sourceChannel) {
         boolean sendResponse = false;
         try {
+            if ( !sourceChannel.isOpen() )
+            {
+                return;
+            }
+
+            if ( !sourceChannel.isReadResumed() )
+            {
+                sourceChannel.getReadSetter().set(this);
+                sourceChannel.resumeReads();
+            }
+
             final int read = doRead(sourceChannel);
 
             if (read <= 0) {


### PR DESCRIPTION
There are lots of the following errors in the log, let's add the check to avoid this.
` java.io.IOException: Connection reset by peer
	at java.base/sun.nio.ch.FileDispatcherImpl.read0(Native Method)
	at java.base/sun.nio.ch.SocketDispatcher.read(SocketDispatcher.java:39)
	at java.base/sun.nio.ch.IOUtil.readIntoNativeBuffer(IOUtil.java:276)
	at java.base/sun.nio.ch.IOUtil.read(IOUtil.java:245)
	at java.base/sun.nio.ch.IOUtil.read(IOUtil.java:223)
	at java.base/sun.nio.ch.SocketChannelImpl.read(SocketChannelImpl.java:358)
	at org.xnio.nio.NioSocketConduit.read(NioSocketConduit.java:289)
	at org.xnio.conduits.ConduitStreamSourceChannel.read(ConduitStreamSourceChannel.java:127)
	at org.commonjava.indy.service.httprox.handler.ProxyRequestReader.doRead(ProxyRequestReader.java:149)
	at org.commonjava.indy.service.httprox.handler.ProxyRequestReader.handleEvent(ProxyRequestReader.java:75)
	at org.commonjava.indy.service.httprox.handler.ProxyRequestReader.handleEvent(ProxyRequestReader.java:48)
	at org.xnio.ChannelListeners.invokeChannelListener(ChannelListeners.java:92)
	at org.xnio.conduits.ReadReadyHandler$ChannelListenerHandler.readReady(ReadReadyHandler.java:66)
	at org.xnio.nio.NioSocketConduit.handleReady(NioSocketConduit.java:89)
	at org.xnio.nio.WorkerThread.run(WorkerThread.java:591)`