### PR TITLE
Fix the format of the header

### DIFF
--- a/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyResponseWriter.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyResponseWriter.java
@@ -283,7 +283,7 @@ public final class ProxyResponseWriter
                                 // reader direct it to tunnel to MITM. MITM finish the handshake and read the request data,
                                 // retrieve remote content and send back to tunnel to client.
                                 http.writeStatus( ApplicationStatus.OK );
-                                http.writeHeader( "Status", "200 OK\n" );
+                                http.writeHeader( "Status", "200 OK\r\n" );
 
                                 break;
                             }


### PR DESCRIPTION
Fix the format of the header according to https://www.rfc-editor.org/rfc/rfc2616
which is the root cause that why `npm install` does not sent get request after connection established.

