### PR TITLE
Use base64 to take query string into encoded path

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
                 expression { env.CHANGE_ID != null } // Pull request
             }
             steps {
-                sh '${M2_HOME}/bin/mvn -Dplugin.jacoco.skip=false -B -V clean verify sonar:sonar -Prun-its'
+                sh '${M2_HOME}/bin/mvn -Dplugin.jacoco.skip=false -B -V clean verify -Prun-its'
             }
         }
         stage('Load OCP Mappings') {

--- a/src/main/java/org/commonjava/indy/service/httprox/handler/AbstractProxyRepositoryCreator.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/handler/AbstractProxyRepositoryCreator.java
@@ -28,11 +28,17 @@ import static org.commonjava.indy.model.core.ArtifactStore.METADATA_ORIGIN;
 import static org.commonjava.indy.model.core.ArtifactStore.TRACKING_ID;
 import static org.commonjava.indy.model.core.GenericPackageTypeDescriptor.GENERIC_PKG_KEY;
 import static org.commonjava.indy.model.core.PathStyle.hashed;
+import static org.commonjava.indy.model.core.StoreType.group;
 import static org.commonjava.indy.service.httprox.util.HttpProxyConstants.PROXY_REPO_PREFIX;
+import static org.commonjava.indy.service.httprox.util.UrlUtils.hasQueryParam;
 
 public abstract class AbstractProxyRepositoryCreator
                 implements ProxyRepositoryCreator
 {
+    private static final String ATTR_PATH_ENCODE = "path-encode";
+
+    private static final String PATH_ENCODE_BASE64 = "base64";
+
     @Override
     public abstract ProxyCreationResult create(String trackingID, String name, String baseUrl, UrlInfo urlInfo,
                                                UserPass userPass, Logger logger );
@@ -115,6 +121,10 @@ public abstract class AbstractProxyRepositoryCreator
         if ( trackingID != null )
         {
             store.setMetadata( TRACKING_ID, trackingID );
+        }
+        if ( store.getType() != group && hasQueryParam(info.getUrl()) )
+        {
+            store.setMetadata( ATTR_PATH_ENCODE, PATH_ENCODE_BASE64 );
         }
     }
 

--- a/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyMITMSSLServer.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyMITMSSLServer.java
@@ -211,7 +211,7 @@ public class ProxyMITMSSLServer implements Runnable
                             }
                         }
 
-                        logger.debug( "Request:\n{}", sb.toString() );
+                        logger.debug( "Request:\n{}", sb );
 
                         if ( path != null )
                         {
@@ -268,21 +268,18 @@ public class ProxyMITMSSLServer implements Runnable
         }
     }
 
-    private void transferRemote( Socket socket, String host, int port, String method, String path, ProxyMeter meter ) throws Exception
+    private void transferRemote( Socket socket, String host, int port, String method, String file,
+                                 ProxyMeter meter ) throws Exception
     {
         String protocol = "https";
-        String auth = null;
-        String query = null;
-        String fragment = null;
-        URI uri = new URI( protocol, auth, host, port, path, query, fragment );
-        URL remoteUrl = uri.toURL();
-        logger.debug( "Requesting remote URL: {}", remoteUrl.toString() );
+        URL remoteUrl = new URL( protocol, host, port, file );
+        logger.debug( "Requesting remote URL: {}", remoteUrl );
 
         ArtifactStore store = proxyResponseHelper.getArtifactStore( trackingId, remoteUrl );
         try (BufferedOutputStream out = new BufferedOutputStream( socket.getOutputStream() );
              HttpConduitWrapper http = new HttpConduitWrapper( new OutputStreamSinkChannel( out ), null ))
         {
-            proxyResponseHelper.transfer( http, store, remoteUrl.getPath(), GET_METHOD.equals( method ),
+            proxyResponseHelper.transfer( http, store, remoteUrl.getFile(), GET_METHOD.equals( method ),
                     proxyUserPass, meter );
             out.flush();
         }

--- a/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyResponseWriter.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyResponseWriter.java
@@ -227,9 +227,11 @@ public final class ProxyResponseWriter
                             case HEAD_METHOD:
                             {
                                 final URL url = new URL( requestLine.getUri() );
-                                logger.debug( "getArtifactStore starts, trackingId: {}, url: {}", trackingId, url );
+                                logger.debug( "Get artifact store, trackingId: {}, url: {}", trackingId, url );
                                 ArtifactStore store = proxyResponseHelper.getArtifactStore( trackingId, url );
-                                proxyResponseHelper.transfer( http, store, url.getPath(), GET_METHOD.equals( method ), proxyUserPass, meter );
+                                // 'url.getFile()' gets the file name of this URL. The returned file portion will be the
+                                // same as getPath(), plus the concatenation of the value of getQuery(), if any.
+                                proxyResponseHelper.transfer( http, store, url.getFile(), GET_METHOD.equals( method ), proxyUserPass, meter );
                                 break;
                             }
                             case OPTIONS_METHOD:

--- a/src/main/java/org/commonjava/indy/service/httprox/util/UrlUtils.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/util/UrlUtils.java
@@ -15,9 +15,12 @@
  */
 package org.commonjava.indy.service.httprox.util;
 
+import org.apache.commons.codec.binary.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -164,5 +167,17 @@ public final class UrlUtils
         }
 
         return sb.toString();
+    }
+
+    /**
+     * Encode path using a URL-safe base64 algorithm if there are query parameters.
+     */
+    public static String base64url(String path) throws UnsupportedEncodingException
+    {
+        if (path.contains("?"))
+        {
+            return Base64.encodeBase64URLSafeString(path.getBytes(StandardCharsets.UTF_8));
+        }
+        return path;
     }
 }

--- a/src/main/java/org/commonjava/indy/service/httprox/util/UrlUtils.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/util/UrlUtils.java
@@ -172,12 +172,17 @@ public final class UrlUtils
     /**
      * Encode path using a URL-safe base64 algorithm if there are query parameters.
      */
-    public static String base64url(String path) throws UnsupportedEncodingException
+    public static String base64url(String path)
     {
-        if (path.contains("?"))
+        if ( hasQueryParam(path) )
         {
             return Base64.encodeBase64URLSafeString(path.getBytes(StandardCharsets.UTF_8));
         }
         return path;
+    }
+
+    public static boolean hasQueryParam( String path )
+    {
+        return path.contains("?");
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,11 @@
 quarkus:
   log:
     level: INFO
+    category:
+      "org.commonjava.indy.service.httprox":
+        level: DEBUG
+      "org.commonjava.indy.model":
+        level: ERROR
   http:
     host-enabled: false
   opentelemetry:

--- a/src/test/java/org/commonjava/service/httprox/AbstractGenericProxyTest.java
+++ b/src/test/java/org/commonjava/service/httprox/AbstractGenericProxyTest.java
@@ -41,12 +41,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.mockito.Mockito;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
 
+import static org.commonjava.indy.service.httprox.util.UrlUtils.base64url;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.*;
 
 public class AbstractGenericProxyTest
 {
@@ -65,7 +66,8 @@ public class AbstractGenericProxyTest
 
         Mockito.when(contentRetrievalService.doGet(any(), any(), any(), contains("indy-api-1.3.1.pom"))).thenReturn(Uni.createFrom().item(buildResponse("indy-api-1.3.1.pom")));
         Mockito.when(contentRetrievalService.doGet(any(), any(), any(), contains("fsevents-1.2.4.tgz"))).thenReturn(Uni.createFrom().item(buildResponse("fsevents-1.2.4.tgz")));
-        Mockito.when(contentRetrievalService.doGet(any(), any(), any(), contains("simple.pom"))).thenReturn(Uni.createFrom().item(buildResponse("simple.pom")));
+        Mockito.when(contentRetrievalService.doGet(any(), any(), any(), eq("/test/org/test/simple/1/simple.pom"))).thenReturn(Uni.createFrom().item(buildResponse("simple.pom")));
+        Mockito.when(contentRetrievalService.doGet(any(), any(), any(), eq(base64url("/org/test/simple.pom?version=2.0")))).thenReturn(Uni.createFrom().item(buildResponse("simple-2.0.pom")));
         Mockito.when(contentRetrievalService.doGet(any(), any(), any(), contains("simple-1.pom"))).thenReturn(Uni.createFrom().item(buildResponse("simple-1.pom")));
         Mockito.when(contentRetrievalService.doGet(any(), any(), any(), contains("no.pom"))).thenReturn(Uni.createFrom().item(buildResponse("no.pom")));
 
@@ -225,6 +227,13 @@ public class AbstractGenericProxyTest
         file.getParentFile().mkdirs();
         FileUtils.copyInputStreamToFile(
                 Thread.currentThread().getContextClassLoader().getResourceAsStream( resourcePath ), file );
+    }
+
+    protected String loadResource(String resource) throws IOException
+    {
+        final InputStream stream = Thread.currentThread().getContextClassLoader().getResourceAsStream( resource );
+        assert stream != null;
+        return IOUtils.toString( stream, StandardCharsets.UTF_8);
     }
 
 }

--- a/src/test/java/org/commonjava/service/httprox/HttpProxyTest.java
+++ b/src/test/java/org/commonjava/service/httprox/HttpProxyTest.java
@@ -36,7 +36,6 @@ import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
@@ -64,8 +63,6 @@ public class HttpProxyTest extends AbstractGenericProxyTest
     public void proxySimplePomAndAutoCreateRemoteRepo()
             throws Exception
     {
-        final String testRepo = "test";
-
         final String url = "http://remote.example:80/test/org/test/simple/1/simple.pom";
         final String testPomContents = loadResource("simple.pom");
 
@@ -87,12 +84,12 @@ public class HttpProxyTest extends AbstractGenericProxyTest
         {
             IOUtils.closeQuietly( stream );
         }
-
-        //TODO check if remote repo created
-        //repositoryService.repoExists("GENERIC_PKG_KEY", StoreType.remote.name(), "httprox_remote-example_80");
-
     }
 
+    /**
+     * If path contains '?', the proxy will create the remote repo with attribute 'path-encode':'base64'. When sending
+     * the request to remote site, the 'path+query' will be encoded.
+     */
     @Test
     public void proxySimplePomWithQueryParameter()
             throws Exception

--- a/src/test/java/org/commonjava/service/httprox/ProxyHttpsTest.java
+++ b/src/test/java/org/commonjava/service/httprox/ProxyHttpsTest.java
@@ -19,6 +19,8 @@ import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
 import static io.smallrye.common.constraint.Assert.assertTrue;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @QuarkusTest
 public class ProxyHttpsTest extends AbstractGenericProxyTest
@@ -28,14 +30,24 @@ public class ProxyHttpsTest extends AbstractGenericProxyTest
 
     private static final String PASS = "password";
 
-    String https_url =
+    final String httpsUrl =
             "https://oss.sonatype.org/content/repositories/releases/org/commonjava/indy/indy-api/1.3.1/indy-api-1.3.1.pom";
 
     @Test
     public void run() throws Exception
     {
-        String ret = get( https_url, true, USER, PASS );
+        String ret = get( httpsUrl, true, USER, PASS );
         assertTrue( ret.contains( "<artifactId>indy-api</artifactId>" ) );
 
+    }
+
+    final String httpsUrlWithQuery = "https://really.useful.script/org/test/simple.pom?version=2.0";
+
+    @Test
+    public void runWithQuery() throws Exception
+    {
+        String ret = get( httpsUrlWithQuery, true, USER, PASS );
+        final String expected = loadResource("simple-2.0.pom");
+        assertThat( ret, equalTo( expected ) );
     }
 }

--- a/src/test/resources/simple-2.0.pom
+++ b/src/test/resources/simple-2.0.pom
@@ -1,0 +1,23 @@
+<!--
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.test</groupId>
+    <artifactId>simple</artifactId>
+    <version>2.0</version>
+</project>


### PR DESCRIPTION
This is for [MMENG-3880](https://issues.redhat.com/browse/MMENG-3880) - Take query string into account when downloading through generic proxy.
It encodes query parameters in remote urls by safe base64 before sending request to content service. This is one part of the whole picture. The other part is on main Indy (content service). The content service needs to recognize the encoded url and decode it before sending request to remote site.
I will hold this pr until the other part is ready. Meanwhile, this pr is ready for review. 