### PR TITLE
Encode all path whether or not hasQueryParam

### DIFF
--- a/src/main/java/org/commonjava/indy/service/httprox/handler/AbstractProxyRepositoryCreator.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/handler/AbstractProxyRepositoryCreator.java
@@ -30,7 +30,6 @@ import static org.commonjava.indy.model.core.GenericPackageTypeDescriptor.GENERI
 import static org.commonjava.indy.model.core.PathStyle.hashed;
 import static org.commonjava.indy.model.core.StoreType.group;
 import static org.commonjava.indy.service.httprox.util.HttpProxyConstants.PROXY_REPO_PREFIX;
-import static org.commonjava.indy.service.httprox.util.UrlUtils.hasQueryParam;
 
 public abstract class AbstractProxyRepositoryCreator
                 implements ProxyRepositoryCreator
@@ -122,7 +121,7 @@ public abstract class AbstractProxyRepositoryCreator
         {
             store.setMetadata( TRACKING_ID, trackingID );
         }
-        if ( store.getType() != group && hasQueryParam(info.getUrl()) )
+        if ( store.getType() != group )
         {
             store.setMetadata( ATTR_PATH_ENCODE, PATH_ENCODE_BASE64 );
         }

--- a/src/main/java/org/commonjava/indy/service/httprox/util/UrlUtils.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/util/UrlUtils.java
@@ -174,15 +174,7 @@ public final class UrlUtils
      */
     public static String base64url(String path)
     {
-        if ( hasQueryParam(path) )
-        {
-            return Base64.encodeBase64URLSafeString(path.getBytes(StandardCharsets.UTF_8));
-        }
-        return path;
+        return Base64.encodeBase64URLSafeString(path.getBytes(StandardCharsets.UTF_8));
     }
 
-    public static boolean hasQueryParam( String path )
-    {
-        return path.contains("?");
-    }
 }

--- a/src/test/java/org/commonjava/service/httprox/AbstractGenericProxyTest.java
+++ b/src/test/java/org/commonjava/service/httprox/AbstractGenericProxyTest.java
@@ -64,12 +64,12 @@ public class AbstractGenericProxyTest
 
         ContentRetrievalService contentRetrievalService = Mockito.mock(ContentRetrievalService.class);
 
-        Mockito.when(contentRetrievalService.doGet(any(), any(), any(), contains("indy-api-1.3.1.pom"))).thenReturn(Uni.createFrom().item(buildResponse("indy-api-1.3.1.pom")));
-        Mockito.when(contentRetrievalService.doGet(any(), any(), any(), contains("fsevents-1.2.4.tgz"))).thenReturn(Uni.createFrom().item(buildResponse("fsevents-1.2.4.tgz")));
-        Mockito.when(contentRetrievalService.doGet(any(), any(), any(), eq("/test/org/test/simple/1/simple.pom"))).thenReturn(Uni.createFrom().item(buildResponse("simple.pom")));
+        Mockito.when(contentRetrievalService.doGet(any(), any(), any(), contains(base64url("indy-api-1.3.1.pom")))).thenReturn(Uni.createFrom().item(buildResponse("indy-api-1.3.1.pom")));
+        Mockito.when(contentRetrievalService.doGet(any(), any(), any(), contains(base64url("fsevents-1.2.4.tgz")))).thenReturn(Uni.createFrom().item(buildResponse("fsevents-1.2.4.tgz")));
+        Mockito.when(contentRetrievalService.doGet(any(), any(), any(), eq(base64url("/test/org/test/simple/1/simple.pom")))).thenReturn(Uni.createFrom().item(buildResponse("simple.pom")));
         Mockito.when(contentRetrievalService.doGet(any(), any(), any(), eq(base64url("/org/test/simple.pom?version=2.0")))).thenReturn(Uni.createFrom().item(buildResponse("simple-2.0.pom")));
-        Mockito.when(contentRetrievalService.doGet(any(), any(), any(), contains("simple-1.pom"))).thenReturn(Uni.createFrom().item(buildResponse("simple-1.pom")));
-        Mockito.when(contentRetrievalService.doGet(any(), any(), any(), contains("no.pom"))).thenReturn(Uni.createFrom().item(buildResponse("no.pom")));
+        Mockito.when(contentRetrievalService.doGet(any(), any(), any(), contains(base64url("simple-1.pom")))).thenReturn(Uni.createFrom().item(buildResponse("simple-1.pom")));
+        Mockito.when(contentRetrievalService.doGet(any(), any(), any(), contains(base64url("no.pom")))).thenReturn(Uni.createFrom().item(buildResponse("no.pom")));
 
         QuarkusMock.installMockForType(contentRetrievalService, ContentRetrievalService.class);
 


### PR DESCRIPTION
The prev pr only encoded paths with query parameters. But that was not nice because it confused us as whether a proxy created repo is encoded or not. This fix treat all proxy generated repo as base64 encoded.