### PR TITLE
Add logger for tracking the store response

### DIFF
--- a/src/main/java/org/commonjava/indy/service/httprox/util/ProxyResponseHelper.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/util/ProxyResponseHelper.java
@@ -104,6 +104,11 @@ public class ProxyResponseHelper
             try
             {
                 store = doGetArtifactStore( trackingId, url );
+
+                if ( store != null )
+                {
+                    logger.info("Got the store {} with trackingId {} and url {}", store.getKey(), trackingId, url);
+                }
             }
             finally
             {


### PR DESCRIPTION
Last week there was a stuck happening in generic proxy on production, I checked the logs and cannot find the cause for it. Adding this for tracking the request for store info and hope we can grab more info in next time. 