### PR TITLE
Add config storage.path.style and default to hashed

### DIFF
--- a/src/main/java/org/commonjava/indy/service/httprox/config/ProxyConfiguration.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/config/ProxyConfiguration.java
@@ -16,12 +16,11 @@
 package org.commonjava.indy.service.httprox.config;
 
 import io.quarkus.runtime.Startup;
+import org.commonjava.indy.model.core.PathStyle;
 import org.commonjava.indy.service.httprox.model.TrackingType;
-import org.commonjava.propulsor.config.annotation.ConfigName;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
 import java.util.Optional;
 
 @Startup
@@ -40,6 +39,8 @@ public class ProxyConfiguration
     private static final int DEFAULT_WORKER_IO_THREADS = 10;
 
     private static final int DEFAULT_WORKER_TASK_THREADS = 10;
+
+    private static final String DEFAULT_STORAGE_PATH_STYLE = PathStyle.hashed.name();
 
     @ConfigProperty(name = "proxy.port")
     Optional<Integer> port;
@@ -73,6 +74,9 @@ public class ProxyConfiguration
 
     @ConfigProperty(name="proxy.worker.task.threads")
     public Integer taskThreads;
+
+    @ConfigProperty(name="storage.path.style")
+    public String storagePathStyle;
 
     public Integer getPort() {
         return port.orElse(8081);
@@ -177,5 +181,15 @@ public class ProxyConfiguration
 
     public void setTaskThreads(Integer taskThreads) {
         this.taskThreads = taskThreads;
+    }
+
+    public String getStoragePathStyle()
+    {
+        return storagePathStyle == null ? DEFAULT_STORAGE_PATH_STYLE : storagePathStyle;
+    }
+
+    public void setStoragePathStyle(String storagePathStyle)
+    {
+        this.storagePathStyle = storagePathStyle;
     }
 }

--- a/src/main/java/org/commonjava/indy/service/httprox/handler/AbstractProxyRepositoryCreator.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/handler/AbstractProxyRepositoryCreator.java
@@ -27,8 +27,6 @@ import java.util.function.Predicate;
 import static org.commonjava.indy.model.core.ArtifactStore.METADATA_ORIGIN;
 import static org.commonjava.indy.model.core.ArtifactStore.TRACKING_ID;
 import static org.commonjava.indy.model.core.GenericPackageTypeDescriptor.GENERIC_PKG_KEY;
-import static org.commonjava.indy.model.core.PathStyle.base64url;
-import static org.commonjava.indy.model.core.PathStyle.hashed;
 import static org.commonjava.indy.model.core.StoreType.group;
 import static org.commonjava.indy.service.httprox.util.HttpProxyConstants.PROXY_REPO_PREFIX;
 
@@ -115,7 +113,7 @@ public abstract class AbstractProxyRepositoryCreator
     private void setPropsAndMetadata(ArtifactStore store, String trackingID, UrlInfo info )
     {
         store.setDescription( "HTTProx proxy based on: " + info.getUrl() );
-        store.setPathStyle( base64url );
+        store.setPathStyle( getPathStyle() );
 
         store.setMetadata( METADATA_ORIGIN, ProxyAcceptHandler.HTTPROX_ORIGIN );
         if ( trackingID != null )
@@ -127,6 +125,8 @@ public abstract class AbstractProxyRepositoryCreator
             store.setMetadata( ATTR_PATH_ENCODE, PATH_ENCODE_BASE64 );
         }
     }
+
+    protected abstract PathStyle getPathStyle();
 
     /**
      * Get the remote repo names with name starts with base name (PROXY_REPO_PREFIX + host + "_" + port)

--- a/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyAcceptHandler.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyAcceptHandler.java
@@ -113,7 +113,7 @@ public class ProxyAcceptHandler implements ChannelListener<AcceptingChannel<Stre
         final ConduitStreamSourceChannel source = accepted.getSourceChannel();
         final ConduitStreamSinkChannel sink = accepted.getSinkChannel();
 
-        ProxyRepositoryCreator repoCreator = new RepoCreator();
+        ProxyRepositoryCreator repoCreator = new RepoCreator( config );
 
         final ProxyResponseWriter writer =
                 new ProxyResponseWriter( config, repoCreator, accepted, repositoryService, contentRetrievalService, proxyExecutor.getExecutor(), proxyAuthenticator, objectMapper, cacheProducer, start, otel );

--- a/src/main/java/org/commonjava/indy/service/httprox/util/RepoCreator.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/util/RepoCreator.java
@@ -17,7 +17,9 @@ package org.commonjava.indy.service.httprox.util;
 
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.PathStyle;
 import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.service.httprox.config.ProxyConfiguration;
 import org.commonjava.indy.service.httprox.handler.AbstractProxyRepositoryCreator;
 import org.commonjava.indy.service.httprox.handler.ProxyCreationResult;
 import org.slf4j.Logger;
@@ -26,6 +28,11 @@ import java.util.function.Predicate;
 
 public class RepoCreator extends AbstractProxyRepositoryCreator
 {
+    private ProxyConfiguration config;
+    public RepoCreator( ProxyConfiguration config )
+    {
+        this.config = config;
+    }
 
     public Predicate<ArtifactStore> getNameFilter(String name )
     {
@@ -54,6 +61,12 @@ public class RepoCreator extends AbstractProxyRepositoryCreator
             ret.setGroup(createGroup(trackingID, groupName, urlInfo, logger, remote.getKey(), hosted.getKey()));
         }
         return ret;
+    }
+
+    @Override
+    protected PathStyle getPathStyle()
+    {
+        return PathStyle.valueOf( config.getStoragePathStyle() );
     }
 
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -63,6 +63,11 @@ MITM:
 tracking:
   type: SUFFIX
 
+## [storage] - preferred is 'base64url' (for backward compatible, default is 'hashed'). User needs to update dep >= org.commonjava.indy.service:indy-model-core-java:1.5
+storage:
+  path:
+    style: hashed
+
 ## [rest client]
 repo-service-api/mp-rest/uri: http://localhost:8080
 repo-service-api/mp-rest/scope: javax.inject.Singleton
@@ -82,7 +87,3 @@ auth:
     resource: indy
   ui:
     resource: indy-ui
-
-
-
-


### PR DESCRIPTION
The new enum value 'base64url' breaks pnc client, as in [NCL-8287](https://issues.redhat.com/browse/NCL-8287). I add a config for it. For backward compatible, default is 'hashed'.

We can switch to new value only after PNC has updated the dependency.