### PR TITLE
Refine the locker against the funtion getArtifactStore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,12 @@
             <version>${infinispanVersion}</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>23.6-jre</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/org/commonjava/indy/service/httprox/util/LockWrapper.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/util/LockWrapper.java
@@ -1,0 +1,17 @@
+package org.commonjava.indy.service.httprox.util;
+
+import com.google.common.util.concurrent.Striped;
+
+import java.util.concurrent.locks.Lock;
+
+public class LockWrapper
+{
+
+    private final static Striped<Lock> striped = Striped.lock(50);
+
+    public static Lock getLockByKey( String key )
+    {
+        return striped.get( key );
+    }
+
+}


### PR DESCRIPTION
After testing locally, I suspect this part may cause the stuck somehow, and let's use the way `lockByKey` to avoid to block all the executor here, since it's no sense to block two if they are different requests. 