### PR TITLE
Add the setting to control the connections

### DIFF
--- a/src/main/java/org/commonjava/indy/service/httprox/HttpProxy.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/HttpProxy.java
@@ -85,7 +85,7 @@ public class HttpProxy {
                 config.setPort(addr.getPort());
             } else {
                 addr = new InetSocketAddress(bind, config.getPort());
-                server = worker.createStreamConnectionServer(addr, acceptHandler, OptionMap.EMPTY);
+                server = worker.createStreamConnectionServer(addr, acceptHandler, config.getHighWater() == 0 ? OptionMap.EMPTY : OptionMap.builder().set(Options.CONNECTION_HIGH_WATER,  config.getHighWater()).getMap());
 
                 server.resumeAccepts();
             }

--- a/src/main/java/org/commonjava/indy/service/httprox/config/ProxyConfiguration.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/config/ProxyConfiguration.java
@@ -75,6 +75,9 @@ public class ProxyConfiguration
     @ConfigProperty(name="proxy.worker.task.threads")
     public Integer taskThreads;
 
+    @ConfigProperty(name="proxy.worker.connection.high-water")
+    public Integer highWater;
+
     @ConfigProperty(name="storage.path.style")
     public String storagePathStyle;
 
@@ -191,5 +194,14 @@ public class ProxyConfiguration
     public void setStoragePathStyle(String storagePathStyle)
     {
         this.storagePathStyle = storagePathStyle;
+    }
+
+
+    public Integer getHighWater() {
+        return highWater;
+    }
+
+    public void setHighWater(Integer highWater) {
+        this.highWater = highWater;
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -37,6 +37,8 @@ proxy:
       threads: 10
     task:
       threads: 10
+  connection:
+    high-water: 50
 
 service_proxy:
   read-timeout: 30m

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -37,8 +37,8 @@ proxy:
       threads: 10
     task:
       threads: 10
-  connection:
-    high-water: 50
+    connection:
+      high-water: 50
 
 service_proxy:
   read-timeout: 30m


### PR DESCRIPTION
After test locally I found that this configuration can control the incoming connections to our proxy server, to avoid the cases that some npm/yarn builds triggered lots of the request at the very same time, which may cause the stuck in the proxy server due to the exhaustion of resources. for example the following part of the logs I grabbed for the build:
https://privatebin.corp.redhat.com/?3540fffd9e3fa72e#Fh2EKSjHzbRK26d5XvQStVpFdDDprnwvnum9fqSek2oS
This will be useful especially we have fewer resources than before in indy monolith. 