### PR TITLE
Update keycloakVersion to 13.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <quarkus-plugin.version>2.3.0.Final</quarkus-plugin.version>
         <bouncycastleVersion>1.64</bouncycastleVersion>
         <weftVersion>1.22</weftVersion>
-        <keycloakVersion>8.0.2</keycloakVersion>
+        <keycloakVersion>22.0.3</keycloakVersion>
         <quarkus.package.type>uber-jar</quarkus.package.type>
         <infinispanVersion>12.1.11.Final</infinispanVersion>
     </properties>


### PR DESCRIPTION
The quay.io report a new Critical after updating to org.keycloak:keycloak-core:8.0.2. As it suggested, I update it again to 13.0.0.