### PR TITLE
Fix the tracking logic

### DIFF
--- a/src/main/java/org/commonjava/indy/service/httprox/util/RepoCreator.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/util/RepoCreator.java
@@ -58,7 +58,7 @@ public class RepoCreator extends AbstractProxyRepositoryCreator
             ret.setHosted(hosted);
 
             String groupName = formatId(host, port, 0, trackingID, "group");
-            ret.setGroup(createGroup(trackingID, groupName, urlInfo, logger, remote.getKey(), hosted.getKey()));
+            ret.setGroup(createGroup(trackingID, groupName, urlInfo, logger, hosted.getKey(), remote.getKey()));
         }
         return ret;
     }


### PR DESCRIPTION
Fix for MMENG-3973:

- the artifacts which are backed up in the hosted repo should be reused afterwards, to support rebuilding. 
- this PR adjusts the order of the constituents of the group, having the hosted repo as the first constituent and the remote one as the second.
- only the request with suffix `+tracking` will be tracked