### PR TITLE
Fix the infinite loop issue when writing to channel

### DIFF
--- a/src/main/java/org/commonjava/indy/service/httprox/handler/ProxySSLTunnel.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/handler/ProxySSLTunnel.java
@@ -111,9 +111,20 @@ public class ProxySSLTunnel implements Runnable
             //byteBuffer.get( bytes );
 
             logger.debug( "Write to sink channel, size: {}", byteBuffer.limit() );
-            ChannelUtils.write( sinkChannel, byteBuffer );
-            sinkChannel.flush();
-            byteBuffer.clear();
+            try
+            {
+                ChannelUtils.write( sinkChannel, byteBuffer );
+            }
+            catch ( IOException e )
+            {
+                logger.debug( "Write to sink channel breaks, {}", e.toString() );
+                break;
+            }
+            finally
+            {
+                sinkChannel.flush();
+                byteBuffer.clear();
+            }
 
             total += read;
         }


### PR DESCRIPTION
Checking the latest logs on prod, I found that the infinite loop happens somehow, even though there is a timeout setting (5mins) to break the loop, but still causing the timeout from the client. We should make it retry and fail the request earlier. 