### PR TITLE
Properly close channels after MIMT server completed

### DIFF
--- a/src/main/java/org/commonjava/indy/service/httprox/config/ProxyConfiguration.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/config/ProxyConfiguration.java
@@ -30,7 +30,7 @@ public class ProxyConfiguration
 
     private static final boolean DEFAULT_SECURED = false;
 
-    private static final int DEFAULT_MITM_SO_TIMEOUT_MINUTES = 30;
+    private static final int DEFAULT_MITM_SO_TIMEOUT_MINUTES = 3;
 
     private static final String DEFAULT_TRACKING_TYPE = TrackingType.SUFFIX.name();
 

--- a/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyAcceptHandler.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyAcceptHandler.java
@@ -119,7 +119,8 @@ public class ProxyAcceptHandler implements ChannelListener<AcceptingChannel<Stre
         ProxyRepositoryCreator repoCreator = new RepoCreator( config );
 
         final ProxyResponseWriter writer =
-                new ProxyResponseWriter( config, repoCreator, accepted, repositoryService, contentRetrievalService, proxyExecutor, proxyAuthenticator, objectMapper, cacheProducer, start, otel );
+                new ProxyResponseWriter( config, repoCreator, accepted, repositoryService, contentRetrievalService,
+                        proxyExecutor, proxyAuthenticator, objectMapper, cacheProducer, start, otel );
 
         logger.debug("Setting writer: {}", writer);
         sink.getWriteSetter().set(writer);

--- a/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyRequestReader.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyRequestReader.java
@@ -40,8 +40,6 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -49,9 +47,7 @@ public final class ProxyRequestReader
         implements ChannelListener<ConduitStreamSourceChannel> {
     private static final int AWAIT_READABLE_IN_MILLISECONDS = 100;
 
-    private static final List<Character> HEAD_END = Collections.unmodifiableList(
-            Arrays.asList( Character.valueOf( '\r' ), Character.valueOf( '\n' ), Character.valueOf( '\r' ),
-                    Character.valueOf( '\n' ) ) );
+    private static final List<Character> HEAD_END = List.of('\r', '\n', '\r', '\n');
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final ProxyResponseWriter writer;
@@ -230,5 +226,6 @@ public final class ProxyRequestReader
     {
         this.sslTunnel = sslTunnel;
     }
+
 
 }

--- a/src/main/java/org/commonjava/indy/service/httprox/util/HttpConduitWrapper.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/util/HttpConduitWrapper.java
@@ -170,9 +170,13 @@ public class HttpConduitWrapper
         return result;
     }
 
-    public void close()
-            throws IOException {
-        flush(sinkChannel);
-        sinkChannel.shutdownWrites();
+    public void close() throws IOException
+    {
+        if ( isOpen() )
+        {
+            flush(sinkChannel);
+            sinkChannel.shutdownWrites();
+            sinkChannel.close();
+        }
     }
 }


### PR DESCRIPTION
This is for [MMENG-4106](https://issues.redhat.com/browse/MMENG-4106). 

Add method 'closeProperly' to handle all uncaught exceptions and close the channels if necessary. Some other fixes are added to make sure all the sock or streams are closed after the try/catch, and fail fast when timeout. 