### PR TITLE
Add the header Transfer-Encoding into response

### DIFF
--- a/src/main/java/org/commonjava/indy/service/httprox/util/HttpConduitWrapper.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/util/HttpConduitWrapper.java
@@ -105,7 +105,8 @@ public class HttpConduitWrapper
                 {
                     if ( header.getFirst().equalsIgnoreCase( ApplicationHeader.content_length.key() )
                             || header.getFirst().equalsIgnoreCase( ApplicationHeader.last_modified.key() )
-                                || header.getFirst().equalsIgnoreCase( ApplicationHeader.content_type.key() ))
+                                || header.getFirst().equalsIgnoreCase( ApplicationHeader.content_type.key() )
+                                    || header.getFirst().equalsIgnoreCase( ApplicationHeader.transfer_encoding.key() ))
                     {
                         writeHeader(header.getFirst(), header.getSecond());
                     }


### PR DESCRIPTION
Fix for MMENG-4165, there are issues with incomplete downloads and failures when using curl/wget on prod. It maybe caused by missing both `Content-Length` and `Transfer-Encoding`. For some binary files, if there is no content-length from the original response header, we need to return the Transfer-Encoding then. 