### PR TITLE
Revert "Add the header Transfer-Encoding into response"

### DIFF
--- a/src/main/java/org/commonjava/indy/service/httprox/util/HttpConduitWrapper.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/util/HttpConduitWrapper.java
@@ -105,8 +105,7 @@ public class HttpConduitWrapper
                 {
                     if ( header.getFirst().equalsIgnoreCase( ApplicationHeader.content_length.key() )
                             || header.getFirst().equalsIgnoreCase( ApplicationHeader.last_modified.key() )
-                                || header.getFirst().equalsIgnoreCase( ApplicationHeader.content_type.key() )
-                                    || header.getFirst().equalsIgnoreCase( ApplicationHeader.transfer_encoding.key() ))
+                                || header.getFirst().equalsIgnoreCase( ApplicationHeader.content_type.key() ))
                     {
                         writeHeader(header.getFirst(), header.getSecond());
                     }


### PR DESCRIPTION
Reverts Commonjava/indy-generic-proxy-service#94 since this may need corresponding chunked data format. Will check further to see how to fix it. 

