### PR TITLE
Close response when write transfer error

### DIFF
--- a/src/main/java/org/commonjava/indy/service/httprox/util/ProxyResponseHelper.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/util/ProxyResponseHelper.java
@@ -522,6 +522,7 @@ public class ProxyResponseHelper
                             if ( response != null && responseBody != null )
                             {
                                 responseBody.close();
+                                response.close();
                             }
                             transferred = true;
                             transferLatch.countDown();


### PR DESCRIPTION
Close the okhttp3 response object when below error happens. This may have caused the WAIT_CLOSE socket.

2024-07-08 09:32:06,556 ERROR [or.co.in.se.ht.ut.ProxyResponseHelper] (OkHttp http://indy-gateway.indy.svc.cluster.local/...) write transfer error: Connection reset by peer (Write failed): java.net.SocketException: Connection reset by peer (Write failed)
...        
        at java.base/java.io.FilterOutputStream.write(FilterOutputStream.java:108)
        at org.commonjava.indy.service.httprox.util.OutputStreamSinkChannel.write(OutputStreamSinkChannel.java:165)
        at org.commonjava.indy.service.httprox.util.ChannelUtils.write(ChannelUtils.java:53)
        at org.commonjava.indy.service.httprox.util.HttpConduitWrapper.writeExistingTransfer(HttpConduitWrapper.java:134)
        at org.commonjava.indy.service.httprox.util.ProxyResponseHelper.lambda$doTransfer$1(ProxyResponseHelper.java:512)
        at io.smallrye.context.impl.wrappers.SlowContextualConsumer.accept(SlowContextualConsumer.java:21)
        at io.smallrye.mutiny.helpers.UniCallbackSubscriber.onItem(UniCallbackSubscriber.java:73)
        at io.smallrye.mutiny.operators.uni.UniOperatorProcessor.onItem(UniOperatorProcessor.java:47)
...
        at org.commonjava.indy.service.httprox.util.WebClientAdapter$CallAdapter$1.onResponse(WebClientAdapter.java:397)
        at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:519)
