### PR TITLE
Add check for SSL tunnel before closing proxy server

### DIFF
--- a/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyResponseWriter.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/handler/ProxyResponseWriter.java
@@ -283,6 +283,7 @@ public final class ProxyResponseWriter
                                 sslTunnel = new ProxySSLTunnel( sinkChannel, socketChannel, config );
                                 tunnelAndMITMExecutor.submit( sslTunnel );
                                 proxyRequestReader.setProxySSLTunnel( sslTunnel ); // client input will be directed to target socket
+                                svr.setProxySSLTunnel( sslTunnel );
 
                                 // When all is ready, send the 200 to client. Client send the SSL handshake to reader,
                                 // reader direct it to tunnel to MITM. MITM finish the handshake and read the request data,

--- a/src/main/java/org/commonjava/indy/service/httprox/handler/ProxySSLTunnel.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/handler/ProxySSLTunnel.java
@@ -156,4 +156,10 @@ public class ProxySSLTunnel implements Runnable
             logger.error( "Close tunnel selector failed", e );
         }
     }
+
+    public boolean isClosed()
+    {
+        return closed;
+    }
+
 }


### PR DESCRIPTION
This can be reproduced via running curl on ubi7, ref MMENG-4165 for the steps,  that the proxy server closed but there are still remaining bytes in SSL tunnel. 