### PR TITLE
Replace infinispan with the lightweight caffeine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-client-mutiny</artifactId>
         </dependency>
-
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx</artifactId>
@@ -128,25 +127,28 @@
             <artifactId>indy-model-core-java</artifactId>
             <version>${indyModelVersion}</version>
         </dependency>
-        
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-core</artifactId>
             <version>${keycloakVersion}</version>
         </dependency>
+
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-adapter-core</artifactId>
             <version>${keycloakVersion}</version>
         </dependency>
-
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-opentelemetry-exporter-otlp</artifactId>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
         </dependency>
 
         <dependency>
@@ -170,14 +172,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-core-jakarta</artifactId>
-            <version>${infinispanVersion}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-commons-jakarta</artifactId>
-            <version>${infinispanVersion}</version>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/src/main/java/org/commonjava/indy/service/httprox/util/CacheProducer.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/util/CacheProducer.java
@@ -44,8 +44,9 @@ public class CacheProducer
     private Cache buildCache()
     {
         Cache<String, String> cache = Caffeine.newBuilder()
-                    .expireAfterAccess(15, TimeUnit.MINUTES)
-                    .build();
+                .maximumSize( 50 )
+                .expireAfterAccess(15, TimeUnit.MINUTES)
+                .build();
         return cache;
     }
 

--- a/src/main/java/org/commonjava/indy/service/httprox/util/CacheProducer.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/util/CacheProducer.java
@@ -15,44 +15,38 @@
  */
 package org.commonjava.indy.service.httprox.util;
 
-import org.infinispan.Cache;
-import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.manager.DefaultCacheManager;
-import org.infinispan.manager.EmbeddedCacheManager;
-
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
+
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 @ApplicationScoped
 public class CacheProducer
 {
-
-    private EmbeddedCacheManager cacheManager;
 
     private Map<String, Cache> caches = new ConcurrentHashMap<>();
 
     @PostConstruct
     public void start()
     {
-        startEmbeddedManager();
-    }
 
-    private void startEmbeddedManager()
-    {
-        cacheManager = new DefaultCacheManager();
     }
 
     public synchronized <K, V> Cache<K, V> getCache( String named )
     {
-        return caches.computeIfAbsent( named, ( k ) -> buildCache(named));
+        return caches.computeIfAbsent( named, ( k ) -> buildCache());
     }
 
-    private Cache buildCache(String named)
+    private Cache buildCache()
     {
-        cacheManager.defineConfiguration( named, new ConfigurationBuilder().build() );
-        return cacheManager.getCache(named, Boolean.TRUE);
+        Cache<String, String> cache = Caffeine.newBuilder()
+                    .expireAfterAccess(15, TimeUnit.MINUTES)
+                    .build();
+        return cache;
     }
 
 

--- a/src/main/java/org/commonjava/indy/service/httprox/util/ProxyResponseHelper.java
+++ b/src/main/java/org/commonjava/indy/service/httprox/util/ProxyResponseHelper.java
@@ -33,7 +33,7 @@ import org.commonjava.indy.service.httprox.config.ProxyConfiguration;
 import org.commonjava.indy.service.httprox.handler.ProxyCreationResult;
 import org.commonjava.indy.service.httprox.handler.ProxyRepositoryCreator;
 import org.commonjava.indy.service.httprox.model.TrackingKey;
-import org.infinispan.Cache;
+import com.github.benmanes.caffeine.cache.Cache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -151,9 +151,9 @@ public class ProxyResponseHelper
 
             if ( trackingId != null )
             {
-                if ( cache.get( groupName ) != null )
+                if ( cache.getIfPresent( groupName ) != null )
                 {
-                    return (ArtifactStore) cache.get( groupName );
+                    return (ArtifactStore) cache.getIfPresent( groupName );
                 }
 
                 Group group = null;
@@ -165,7 +165,7 @@ public class ProxyResponseHelper
                     if ( response != null && response.getStatus() == HttpStatus.SC_OK )
                     {
                         group = (Group)response.readEntity(ArtifactStore.class);
-                        cache.put(groupName, group, 15, TimeUnit.MINUTES);
+                        cache.put(groupName, group);
                     }
                 }
                 catch ( WebApplicationException e )
@@ -176,7 +176,7 @@ public class ProxyResponseHelper
                                 url, trackingId );
                         ProxyCreationResult result = createRepo( trackingId, url, null );
                         group = result.getGroup();
-                        cache.put(groupName, group, 15, TimeUnit.MINUTES);
+                        cache.put(groupName, group);
                         return group;
                     }
                     else


### PR DESCRIPTION
We plan to integrate this as a sidecar to the mw pipeline, and have to slim the image to avoid the performance issue when download the image each time for mw pipeline running.  We can do this from app level and image level, this PR is for app level, I found two big deps, one is quarkus-opentelemetry and another one is infinispan. 